### PR TITLE
Feature petition for decreasing auditorium meetings on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@ Features:
       <a href="https://www.facebook.com/sharer/sharer.php?u=https://elitegamercj.github.io/GameIsle" target="_blank">Share on Facebook</a>
       <a href="https://twitter.com/intent/tweet?url=https://elitegamercj.github.io/GameIsle&text=Check%20out%20this%20awesome%20game%20website!" target="_blank">Share on Twitter</a>
       <a href="https://bsky.app/intent/compose?url=https://elitegamercj.github.io/GameIsle&text=Check%20out%20this%20awesome%20game%20website!" target="_blank">Share on BSKY</a>
+      <a href="https://www.ipetitions.com/petition/no-auditorium" target="_blank">Sign the Petition to Decrease Auditorium Meetings</a>
     </div>
     
     <!-- New game releases section -->
@@ -96,6 +97,13 @@ Features:
       </div>
     </div>
     
+    <!-- Petition section -->
+    <div class="petition">
+      <h2>Support Our Petition 📢</h2>
+      <p>We are advocating for a decrease in auditorium meetings. Please support us by signing the petition.</p>
+      <a href="https://www.ipetitions.com/petition/no-auditorium" class="custom-button">Sign the Petition</a>
+    </div>
+    
     <script src="myscript.js"></script>
     <script src="script.js"></script>
 
@@ -114,6 +122,7 @@ Features:
       <li>🗺️ Added new routes in `routes/routes.js` to handle category and game pages using Express.js.</li>
       <li>🦺 Added a footer partial in `views/partials/footer.ejs` to include social media sharing options on all pages.</li>
       <li>🧭 Added a navbar partial in `views/partials/navbar.ejs` to provide easy navigation across the website.</li>
+      <li>📢 Added a petition section to support our cause for decreasing auditorium meetings. Please sign the petition <a href="https://www.ipetitions.com/petition/no-auditorium">here</a>.</li>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
Add a petition section to the homepage to feature the petition for decreasing auditorium meetings.

* **Petition Section**:
  - Add a new section mentioning the petition for decreasing auditorium meetings.
  - Include a link to the petition URL `https://www.ipetitions.com/petition/no-auditorium`.
* **Social Media Sharing**:
  - Add the petition to the social media sharing options.
* **New Release Notes**:
  - Mention the petition in the new release notes section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/EliteGamerCJ/GameIsle/pull/23?shareId=7896227c-67c1-4dbb-b2a7-d05796190bf4).